### PR TITLE
Prepend 'baseurl' to images URLs

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -2,7 +2,7 @@
   <a class="posts__link" href="{{ post.url | prepend: site.baseurl }}" itemprop="url">
     {% if post.image %}
       <figure class="posts__img">
-        <img src="{{ post.image }}" alt="{{ post.title }}" data-aos="fade-in" itemprop="image"/>
+        <img src="{{ post.image | prepend: site.baseurl }}" alt="{{ post.title }}" data-aos="fade-in" itemprop="image"/>
       </figure>
     {% endif %}
     <div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@ layout: default
     {% if page.image %}
       <div class="post__img">
         <div>
-          <figure class="absolute-bg" style="background-image: url('{{ page.image }}');"></figure>
+          <figure class="absolute-bg" style="background-image: url('{{ page.image | prepend: site.baseurl }}');"></figure>
         </div>
       </div>
     {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ layout: default
     {% if page.image %}
       <div class="post__img">
         <div>
-          <figure class="absolute-bg" style="background-image: url('{{ page.image }}');"></figure>
+          <figure class="absolute-bg" style="background-image: url('{{ page.image | prepend: site.baseurl }}');"></figure>
         </div>
       </div>
     {% endif %}
@@ -66,7 +66,7 @@ layout: default
             <a class="related__link" href="{{ post.url | absolute_url }}">
               {% if post.image %}
                 <figure class="related__img">
-                  <img src="{{ post.image }}" alt="{{ post.title }}"/>
+                  <img src="{{ post.image | prepend: site.baseurl }}" alt="{{ post.title }}"/>
                 </figure>
               {% endif %}
               <div>


### PR DESCRIPTION
This makes the theme work when the baseURL is not empty. For instance, in Github Pages the baseURL is "/repo_name" - such as in:

username.github.io/repo_name