### PR TITLE
handle multiple authors

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,12 +38,16 @@ layout: default
       </div>
 
       <div class="section-padding">
-        <div class="grid-small">
-          {% for author in site.author %}
-            <span class="post__author">Posted by {% if author["name"] == page.author and author["url"] %}<a href="{{ author['url'] }}" title="More By {{ page.author }}">{% endif %}{{ page.author }}{% if author["name"] == page.author and author["url"] %}</a>{% endif %}</span>
-            {% if author["name"] == page.author %}
-              <p class="post__bio">{{ author["bio"] }}</p>
+        <div class="grid-small"> 
+          {% for author in page.author %}
+            {% assign authorDetails = site.author | where:"name", author %}
+            {% if forloop.first == true %}
+              <span class="post__author">Posted by 
+            {% else %}
+              <span class="post__author">and 
             {% endif %}
+            {% if authorDetails[0]["url"] %}<a href="{{ authorDetails[0]['url'] }}" title="More By {{ page.author }}">{% endif %}{{ author }}{% if authorDetails[0]["url"] %}</a>{% endif %}</span>    
+              <p class="post__bio">{{ authorDetails[0]["bio"] }}</p>
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
resolves #19 

adding an additional author, for example:
```
# Author settings
author:
  - name: Thomas Vaeth
    bio: Thomas Vaeth was born in New York, raised in Pennsylvania, and transplanted in Washington. He was a Web Developer at Urban Influence, but now he's a Software Engineer at Getty Images.
    url: http://thomasvaeth.com
  - name: Jane Doe
    bio: Jane Doe is an accomplished writer and this is her bio.
    url: http://janedoe.com
```
will result in this:
![Screen Shot 2019-08-07 at 4 24 49 PM](https://user-images.githubusercontent.com/4806884/62655419-eb12f380-b92f-11e9-8fea-0a4e053abd64.png)

-------

In the post YAML front matter the `author` can be...
```
author: Thomas Vaeth
```
```
author: 
  - Thomas Vaeth
```
```
author: 
 - Thomas Vaeth
 - Jane Doe
```
```
author: [Thomas Vaeth, Jane Doe]
```
```
author: [Thomas Vaeth]
```
```
author: Max Grossman
```
(this last example would be for no match in config file - just shows name, doesn't render link or bio)
