### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ GitHub Pages [does not support]((https://help.github.com/articles/adding-jekyll-
 * Link the repository to [Netlify](https://www.netlify.com/). Netlify will then rebuild the theme every time a commit is pushed to the repo.
 * Finish setting up the [s3-website](https://github.com/klaemo/s3-website) package that is already included in the theme. This would deploy the theme to AWS S3 when ```npm run deploy``` is run.
 
+### Stackbit
+
+This theme is ready to import into Stackbit. It can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS, Sanity or Contentful.
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/samesies/barber-jekyll)
+
 ### Source Code
 The source code is broken down to make finding what you need as easy as possible. Almost everything runs through ````gulpfile.js````, so you will need to run ````npm install```` on your command line before doing any additional development. You can then run ````gulp```` or ````npm run gulp```` to compile everything.
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 email: okay@samesies.io
 baseurl: ""
 permalink: /:year/:month/:day/:title/
-google_analytics: 
+google_analytics: ""
 
 name: Thomas Vaeth
 title: The Barber Theme

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description: >
   Barber is a blog theme for Jekyll built by Thomas Vaeth for Samesies using HTML, Sass, and JavaScript.
 url: http://barber.samesies.io
 twitter_username: thomasvaeth
-default_img: /assets/images/seo.jpg
+default_img: assets/images/seo.jpg
 social:
   - name: twitter
     url: https://twitter.com/thomasvaeth
@@ -24,7 +24,7 @@ social:
     url: https://codepen.io/thomasvaeth/
 
 # Contact settings
-contact_img: /assets/images/placeholder-28.jpg
+contact_img: assets/images/placeholder-28.jpg
 formcarry: https://formcarry.com/s/HkIo0nMb7
 
 # Disqus settings

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -4,7 +4,7 @@
   </div>
   <div class="contact__container popup__container">
     <div class="contact__img">
-      <figure class="absolute-bg" style="background-image: url({{ site.contact_img | prepend: site.baseurl }});"></figure>
+      <figure class="absolute-bg" style="background-image: url({{ site.contact_img | relative_url }});"></figure>
     </div>
     <div class="contact__content">
       <div class="contact__mast section-padding--half">

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -2,7 +2,7 @@
   <a class="posts__link" href="{{ post.url | prepend: site.baseurl }}" itemprop="url">
     {% if post.image %}
       <figure class="posts__img">
-        <img src="{{ post.image }}" alt="{{ post.title }}" data-aos="fade-in" itemprop="image"/>
+        <img src="{{ post.image | relative_url }}" alt="{{ post.title }}" data-aos="fade-in" itemprop="image"/>
       </figure>
     {% endif %}
     <div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@ layout: default
     {% if page.image %}
       <div class="post__img">
         <div>
-          <figure class="absolute-bg" style="background-image: url('{{ page.image }}');"></figure>
+          <figure class="absolute-bg" style="background-image: url('{{ page.image | relative_url }}');"></figure>
         </div>
       </div>
     {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,7 @@ layout: default
     {% if page.image %}
       <div class="post__img">
         <div>
-          <figure class="absolute-bg" style="background-image: url('{{ page.image }}');"></figure>
+          <figure class="absolute-bg" style="background-image: url('{{ page.image | relative_url }}');"></figure>
         </div>
       </div>
     {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -70,7 +70,7 @@ layout: default
             <a class="related__link" href="{{ post.url | absolute_url }}">
               {% if post.image %}
                 <figure class="related__img">
-                  <img src="{{ post.image }}" alt="{{ post.title }}"/>
+                  <img src="{{ post.image | relative_url }}" alt="{{ post.title }}"/>
                 </figure>
               {% endif %}
               <div>

--- a/_posts/2017-10-08-brunch-swag.md
+++ b/_posts/2017-10-08-brunch-swag.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Brunch Swag"
 date: 2017-10-08
-description: 
-image: /assets/images/placeholder-15.jpg
+description: ""
+image: assets/images/placeholder-15.jpg
 author: Thomas Vaeth
 tags:
   - Squid

--- a/_posts/2017-10-09-lumbersexual.md
+++ b/_posts/2017-10-09-lumbersexual.md
@@ -1,30 +1,31 @@
 ---
 layout: post
-title: "Disrupt Raw Denim"
-date: 2017-10-10
-description: 
-image: /assets/images/placeholder-14.jpg
+title: "Lumbersexual"
+date: 2017-10-09
+description: ""
+image: assets/images/placeholder-3.jpg
 author: Thomas Vaeth
-tags: 
-  - Squid
+tags:
   - Mixtape
+  - Moon Drinking
+  - Kale
 ---
 Umami thundercats 90's chia tumblr. [Dreamcatcher](http://thomasvaeth.com/) cronut neutra forage lo-fi. +1 man braid single-origin coffee affogato kinfolk selfies cornhole lumbersexual mlkshk. Meditation you probably haven't heard of them kogi wayfarers ethical bushwick hell of. 
 
-Cray beard succulents mlkshk woke. Hashtag pour-over meh disrupt raw denim narwhal iceland taxidermy helvetica vice. Venmo succulents next level cred, street art messenger bag sartorial sriracha paleo affogato echo park hella normcore seitan. Bicycle rights gochujang mumblecore, woke subway tile selvage microdosing kombucha PBR&B shoreditch readymade XOXO wayfarers mlkshk schlitz. 
+![Placeholder](/assets/images/placeholder-26.jpg#full)
 
-Church-key hell of squid art party man bun, heirloom coloring book narwhal shaman umami raw denim leggings tbh. 
+Cray beard succulents mlkshk woke. Hashtag pour-over meh disrupt raw denim narwhal iceland taxidermy helvetica vice. Venmo succulents next level cred, street art messenger bag sartorial sriracha paleo affogato echo park hella normcore seitan. 
 
-Cred bespoke wayfarers af, retro vaporware PBR&B waistcoat everyday carry cornhole fam narwhal. Chartreuse plaid art party, glossier prism affogato retro hexagon letterpress bitters organic tbh photo booth keytar skateboard. Farm-to-table YOLO ugh four dollar toast brooklyn palo santo brunch lyft lomo cred bitters actually pabst air plant mustache. Prism iPhone health goth chambray meh affogato.
+![Placeholder](/assets/images/placeholder-27.jpg#full)
+
+Bicycle rights gochujang mumblecore, woke subway tile selvage microdosing kombucha PBR&B shoreditch readymade XOXO wayfarers mlkshk schlitz. Church-key hell of squid art party man bun, heirloom coloring book narwhal shaman umami raw denim leggings tbh. Cred bespoke wayfarers af, retro vaporware PBR&B waistcoat everyday carry cornhole fam narwhal. Chartreuse plaid art party, glossier prism affogato retro hexagon letterpress bitters organic tbh photo booth keytar skateboard. Farm-to-table YOLO ugh four dollar toast brooklyn palo santo brunch lyft lomo cred bitters actually pabst air plant mustache. Prism iPhone health goth chambray meh affogato.
 
 ## Four Dollar Toast
-Snackwave keytar mixtape art party, typewriter banh mi YOLO brunch butcher franzen retro hashtag cray. Activated charcoal tote bag tousled, selvage organic edison bulb +1 craft beer locavore swag. 3 wolf moon photo booth bespoke narwhal swag drinking vinegar skateboard flexitarian woke butcher gochujang celiac kitsch. Dreamcatcher deep v hexagon sustainable seitan portland DIY post-ironic. Sartorial aesthetic umami, next level snackwave intelligentsia hot chicken salvia fanny pack poke vice 8-bit. Fam locavore hashtag wolf dreamcatcher actually blog gastropub migas church-key mixtape 90's truffaut trust fund. 
+Snackwave keytar mixtape art party, typewriter banh mi YOLO brunch butcher franzen retro hashtag cray. Activated charcoal tote bag tousled, selvage organic edison bulb +1 craft beer locavore swag. 3 wolf moon photo booth bespoke narwhal swag drinking vinegar skateboard flexitarian woke butcher gochujang celiac kitsch. Dreamcatcher deep v hexagon sustainable seitan portland DIY post-ironic. Sartorial aesthetic umami, next level snackwave intelligentsia hot chicken salvia fanny pack poke vice 8-bit. 
 
-![Placeholder](/assets/images/placeholder-26.jpg)
+Fam locavore hashtag wolf dreamcatcher actually blog gastropub migas church-key mixtape 90's truffaut trust fund. Vegan hammock green juice, migas post-ironic master cleanse cold-pressed wolf kogi celiac four dollar toast brunch hot chicken hell of. Palo santo activated charcoal humblebrag leggings banh mi freegan fingerstache aesthetic cronut 3 wolf moon. 
 
-Vegan hammock green juice, migas post-ironic master cleanse cold-pressed wolf kogi celiac four dollar toast brunch hot chicken hell of. Palo santo activated charcoal humblebrag leggings banh mi freegan fingerstache aesthetic cronut 3 wolf moon. La croix fingerstache twee affogato actually. Crucifix mlkshk tacos chambray church-key etsy. Woke artisan 3 wolf moon, mumblecore pour-over chillwave messenger bag knausgaard master cleanse. Tote bag 90's put a bird on it meh occupy banh mi. Tofu meditation jianbing normcore vexillologist knausgaard williamsburg gochujang retro drinking vinegar. 
-
-Art party skateboard franzen, cornhole fingerstache ennui selvage viral.
+La croix fingerstache twee affogato actually. Crucifix mlkshk tacos chambray church-key etsy. Woke artisan 3 wolf moon, mumblecore pour-over chillwave messenger bag knausgaard master cleanse. Tote bag 90's put a bird on it meh occupy banh mi. Tofu meditation jianbing normcore vexillologist knausgaard williamsburg gochujang retro drinking vinegar. Art party skateboard franzen, cornhole fingerstache ennui selvage viral.
 
 > PBR&B gluten-free pug yuccie photo booth vice readymade chia poke selfies hoodie blue bottle ennui.
 

--- a/_posts/2017-10-10-disrupt-raw-denim.md
+++ b/_posts/2017-10-10-disrupt-raw-denim.md
@@ -1,31 +1,30 @@
 ---
 layout: post
-title: "Lumbersexual"
-date: 2017-10-09
-description: 
-image: /assets/images/placeholder-3.jpg
+title: "Disrupt Raw Denim"
+date: 2017-10-10
+description: ""
+image: assets/images/placeholder-14.jpg
 author: Thomas Vaeth
-tags:
+tags: 
+  - Squid
   - Mixtape
-  - Moon Drinking
-  - Kale
 ---
 Umami thundercats 90's chia tumblr. [Dreamcatcher](http://thomasvaeth.com/) cronut neutra forage lo-fi. +1 man braid single-origin coffee affogato kinfolk selfies cornhole lumbersexual mlkshk. Meditation you probably haven't heard of them kogi wayfarers ethical bushwick hell of. 
 
-![Placeholder](/assets/images/placeholder-26.jpg#full)
+Cray beard succulents mlkshk woke. Hashtag pour-over meh disrupt raw denim narwhal iceland taxidermy helvetica vice. Venmo succulents next level cred, street art messenger bag sartorial sriracha paleo affogato echo park hella normcore seitan. Bicycle rights gochujang mumblecore, woke subway tile selvage microdosing kombucha PBR&B shoreditch readymade XOXO wayfarers mlkshk schlitz. 
 
-Cray beard succulents mlkshk woke. Hashtag pour-over meh disrupt raw denim narwhal iceland taxidermy helvetica vice. Venmo succulents next level cred, street art messenger bag sartorial sriracha paleo affogato echo park hella normcore seitan. 
+Church-key hell of squid art party man bun, heirloom coloring book narwhal shaman umami raw denim leggings tbh. 
 
-![Placeholder](/assets/images/placeholder-27.jpg#full)
-
-Bicycle rights gochujang mumblecore, woke subway tile selvage microdosing kombucha PBR&B shoreditch readymade XOXO wayfarers mlkshk schlitz. Church-key hell of squid art party man bun, heirloom coloring book narwhal shaman umami raw denim leggings tbh. Cred bespoke wayfarers af, retro vaporware PBR&B waistcoat everyday carry cornhole fam narwhal. Chartreuse plaid art party, glossier prism affogato retro hexagon letterpress bitters organic tbh photo booth keytar skateboard. Farm-to-table YOLO ugh four dollar toast brooklyn palo santo brunch lyft lomo cred bitters actually pabst air plant mustache. Prism iPhone health goth chambray meh affogato.
+Cred bespoke wayfarers af, retro vaporware PBR&B waistcoat everyday carry cornhole fam narwhal. Chartreuse plaid art party, glossier prism affogato retro hexagon letterpress bitters organic tbh photo booth keytar skateboard. Farm-to-table YOLO ugh four dollar toast brooklyn palo santo brunch lyft lomo cred bitters actually pabst air plant mustache. Prism iPhone health goth chambray meh affogato.
 
 ## Four Dollar Toast
-Snackwave keytar mixtape art party, typewriter banh mi YOLO brunch butcher franzen retro hashtag cray. Activated charcoal tote bag tousled, selvage organic edison bulb +1 craft beer locavore swag. 3 wolf moon photo booth bespoke narwhal swag drinking vinegar skateboard flexitarian woke butcher gochujang celiac kitsch. Dreamcatcher deep v hexagon sustainable seitan portland DIY post-ironic. Sartorial aesthetic umami, next level snackwave intelligentsia hot chicken salvia fanny pack poke vice 8-bit. 
+Snackwave keytar mixtape art party, typewriter banh mi YOLO brunch butcher franzen retro hashtag cray. Activated charcoal tote bag tousled, selvage organic edison bulb +1 craft beer locavore swag. 3 wolf moon photo booth bespoke narwhal swag drinking vinegar skateboard flexitarian woke butcher gochujang celiac kitsch. Dreamcatcher deep v hexagon sustainable seitan portland DIY post-ironic. Sartorial aesthetic umami, next level snackwave intelligentsia hot chicken salvia fanny pack poke vice 8-bit. Fam locavore hashtag wolf dreamcatcher actually blog gastropub migas church-key mixtape 90's truffaut trust fund. 
 
-Fam locavore hashtag wolf dreamcatcher actually blog gastropub migas church-key mixtape 90's truffaut trust fund. Vegan hammock green juice, migas post-ironic master cleanse cold-pressed wolf kogi celiac four dollar toast brunch hot chicken hell of. Palo santo activated charcoal humblebrag leggings banh mi freegan fingerstache aesthetic cronut 3 wolf moon. 
+![Placeholder](/assets/images/placeholder-26.jpg)
 
-La croix fingerstache twee affogato actually. Crucifix mlkshk tacos chambray church-key etsy. Woke artisan 3 wolf moon, mumblecore pour-over chillwave messenger bag knausgaard master cleanse. Tote bag 90's put a bird on it meh occupy banh mi. Tofu meditation jianbing normcore vexillologist knausgaard williamsburg gochujang retro drinking vinegar. Art party skateboard franzen, cornhole fingerstache ennui selvage viral.
+Vegan hammock green juice, migas post-ironic master cleanse cold-pressed wolf kogi celiac four dollar toast brunch hot chicken hell of. Palo santo activated charcoal humblebrag leggings banh mi freegan fingerstache aesthetic cronut 3 wolf moon. La croix fingerstache twee affogato actually. Crucifix mlkshk tacos chambray church-key etsy. Woke artisan 3 wolf moon, mumblecore pour-over chillwave messenger bag knausgaard master cleanse. Tote bag 90's put a bird on it meh occupy banh mi. Tofu meditation jianbing normcore vexillologist knausgaard williamsburg gochujang retro drinking vinegar. 
+
+Art party skateboard franzen, cornhole fingerstache ennui selvage viral.
 
 > PBR&B gluten-free pug yuccie photo booth vice readymade chia poke selfies hoodie blue bottle ennui.
 

--- a/_posts/2017-10-11-unicorn-echo-park.md
+++ b/_posts/2017-10-11-unicorn-echo-park.md
@@ -1,24 +1,22 @@
 ---
 layout: post
-title: "Beard"
-date: 2017-10-16
-description: 
-image: /assets/images/placeholder-7.jpg
+title: "Unicorn Echo Park"
+date: 2017-10-11
+description: ""
+image: assets/images/placeholder-10.jpg
 author: Thomas Vaeth
 tags: 
-  - Squid
+  - Mixtape
   - Moon Drinking
   - Kale
 ---
 Mlkshk cronut try-hard, microdosing poke man bun kinfolk normcore intelligentsia YOLO helvetica. Dreamcatcher hell of lumbersexual enamel pin intelligentsia green juice you probably haven't heard of them hexagon pitchfork 3 wolf moon blue bottle single-origin coffee cronut brunch. 
 
-![Placeholder](/assets/images/placeholder-25.jpg)
-
-Taxidermy tumblr forage neutra. Af skateboard hoodie scenester, vape fanny pack etsy. 
-
-Blue bottle farm-to-table pabst, vinyl hexagon salvia bespoke hot chicken fanny pack palo santo mixtape. Keytar cloud bread master cleanse, sriracha beard hammock kogi activated charcoal tacos DIY literally gentrify. Vice raw denim whatever mixtape street art put a bird on it copper mug coloring book XOXO craft beer YOLO air plant brooklyn authentic. 
+Taxidermy tumblr forage neutra. Af skateboard hoodie scenester, vape fanny pack etsy. Blue bottle farm-to-table pabst, vinyl hexagon salvia bespoke hot chicken fanny pack palo santo mixtape. Keytar cloud bread master cleanse, sriracha beard hammock kogi activated charcoal tacos DIY literally gentrify. Vice raw denim whatever mixtape street art put a bird on it copper mug coloring book XOXO craft beer YOLO air plant brooklyn authentic. 
 
 Distillery biodiesel unicorn food truck echo park master cleanse. Gentrify mumblecore twee synth, farm-to-table gochujang umami health goth narwhal ugh letterpress coloring book. Mumblecore kogi microdosing tumeric blog gluten-free affogato four loko, pour-over hexagon. Schlitz banjo man bun twee. Unicorn echo park twee asymmetrical gentrify deep v trust fund kitsch squid.
+
+![Placeholder](/assets/images/placeholder-26.jpg#full)
 
 Asymmetrical listicle glossier, bitters distillery biodiesel farm-to-table migas aesthetic woke sriracha. Tbh PBR&B stumptown kickstarter vinyl YOLO mlkshk everyday carry asymmetrical lumbersexual. 
 

--- a/_posts/2017-10-12-butcher-vaporware-keytar.md
+++ b/_posts/2017-10-12-butcher-vaporware-keytar.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Butcher Vaporware Keytar"
 date: 2017-10-12
-description: 
-image: /assets/images/placeholder-13.jpg
+description: ""
+image: assets/images/placeholder-13.jpg
 author: Thomas Vaeth
 tags: 
   - Squid

--- a/_posts/2017-10-13-single-origin-coffee.md
+++ b/_posts/2017-10-13-single-origin-coffee.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Single-origin Coffee"
 date: 2017-10-13
-description: 
-image: /assets/images/placeholder-21.jpg
+description: ""
+image: assets/images/placeholder-21.jpg
 author: Thomas Vaeth
 tags: 
   - Mixtape

--- a/_posts/2017-10-14-snackwave.md
+++ b/_posts/2017-10-14-snackwave.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Snackwave"
 date: 2017-10-14
-description: 
-image: /assets/images/placeholder-11.jpg
+description: ""
+image: assets/images/placeholder-11.jpg
 author: Thomas Vaeth
 tags: 
   - Squid

--- a/_posts/2017-10-15-craft-beer-listicle.md
+++ b/_posts/2017-10-15-craft-beer-listicle.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Craft Beer Listicle"
 date: 2017-10-15
-description: 
-image: /assets/images/placeholder-16.jpg
+description: ""
+image: assets/images/placeholder-16.jpg
 author: Thomas Vaeth
 tags: 
   - Mixtape

--- a/_posts/2017-10-16-beard.md
+++ b/_posts/2017-10-16-beard.md
@@ -1,22 +1,24 @@
 ---
 layout: post
-title: "Unicorn Echo Park"
-date: 2017-10-11
-description: 
-image: /assets/images/placeholder-10.jpg
+title: "Beard"
+date: 2017-10-16
+description: ""
+image: assets/images/placeholder-7.jpg
 author: Thomas Vaeth
 tags: 
-  - Mixtape
+  - Squid
   - Moon Drinking
   - Kale
 ---
 Mlkshk cronut try-hard, microdosing poke man bun kinfolk normcore intelligentsia YOLO helvetica. Dreamcatcher hell of lumbersexual enamel pin intelligentsia green juice you probably haven't heard of them hexagon pitchfork 3 wolf moon blue bottle single-origin coffee cronut brunch. 
 
-Taxidermy tumblr forage neutra. Af skateboard hoodie scenester, vape fanny pack etsy. Blue bottle farm-to-table pabst, vinyl hexagon salvia bespoke hot chicken fanny pack palo santo mixtape. Keytar cloud bread master cleanse, sriracha beard hammock kogi activated charcoal tacos DIY literally gentrify. Vice raw denim whatever mixtape street art put a bird on it copper mug coloring book XOXO craft beer YOLO air plant brooklyn authentic. 
+![Placeholder](/assets/images/placeholder-25.jpg)
+
+Taxidermy tumblr forage neutra. Af skateboard hoodie scenester, vape fanny pack etsy. 
+
+Blue bottle farm-to-table pabst, vinyl hexagon salvia bespoke hot chicken fanny pack palo santo mixtape. Keytar cloud bread master cleanse, sriracha beard hammock kogi activated charcoal tacos DIY literally gentrify. Vice raw denim whatever mixtape street art put a bird on it copper mug coloring book XOXO craft beer YOLO air plant brooklyn authentic. 
 
 Distillery biodiesel unicorn food truck echo park master cleanse. Gentrify mumblecore twee synth, farm-to-table gochujang umami health goth narwhal ugh letterpress coloring book. Mumblecore kogi microdosing tumeric blog gluten-free affogato four loko, pour-over hexagon. Schlitz banjo man bun twee. Unicorn echo park twee asymmetrical gentrify deep v trust fund kitsch squid.
-
-![Placeholder](/assets/images/placeholder-26.jpg#full)
 
 Asymmetrical listicle glossier, bitters distillery biodiesel farm-to-table migas aesthetic woke sriracha. Tbh PBR&B stumptown kickstarter vinyl YOLO mlkshk everyday carry asymmetrical lumbersexual. 
 

--- a/_posts/2017-10-17-taxidermy-dreamcatcher-readymade.md
+++ b/_posts/2017-10-17-taxidermy-dreamcatcher-readymade.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Taxidermy Dreamcatcher Readymade"
 date: 2017-10-17
-description: 
-image: /assets/images/placeholder-6.jpg
+description: ""
+image: assets/images/placeholder-6.jpg
 author: Thomas Vaeth
 tags: 
   - Dummy Text

--- a/_posts/2017-10-18-blue-bottle.md
+++ b/_posts/2017-10-18-blue-bottle.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Blue Bottle"
 date: 2017-10-18
-description: 
-image: /assets/images/placeholder-5.jpg
+description: ""
+image: assets/images/placeholder-5.jpg
 author: Thomas Vaeth
 tags: 
   - Squid

--- a/_posts/2017-10-19-waistcoat-tote-bag-pickled.md
+++ b/_posts/2017-10-19-waistcoat-tote-bag-pickled.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Waistcoat Tote Bag Pickled"
 date: 2017-10-19
-description: 
-image: /assets/images/placeholder-4.jpg
+description: ""
+image: assets/images/placeholder-4.jpg
 author: Thomas Vaeth
 tags: 
   - Dummy Text

--- a/_posts/2017-10-20-roof-party.md
+++ b/_posts/2017-10-20-roof-party.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Roof Party"
 date: 2017-10-20
-description: 
-image: /assets/images/placeholder-1.jpg
+description: ""
+image: assets/images/placeholder-1.jpg
 author: Thomas Vaeth
 tags: 
   - Squid

--- a/_posts/2017-10-21-flannel-distillery-asymmetrical.md
+++ b/_posts/2017-10-21-flannel-distillery-asymmetrical.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Flannel Distillery Asymmetrical"
 date: 2017-10-21
-description: 
-image: /assets/images/placeholder-12.jpg
+description: ""
+image: assets/images/placeholder-12.jpg
 author: Thomas Vaeth
 tags: 
   - Dummy Text

--- a/_posts/2017-10-22-coloring-book.md
+++ b/_posts/2017-10-22-coloring-book.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Coloring Book"
 date: 2017-10-22
-description: 
-image: /assets/images/placeholder-8.jpg
+description: ""
+image: assets/images/placeholder-8.jpg
 author: Thomas Vaeth
 tags: 
   - Squid

--- a/_posts/2017-10-23-polaroid-williamsburg.md
+++ b/_posts/2017-10-23-polaroid-williamsburg.md
@@ -2,8 +2,8 @@
 layout: post
 title: "Polaroid Williamsburg"
 date: 2017-10-23
-description: 
-image: /assets/images/placeholder-9.jpg
+description: ""
+image: assets/images/placeholder-9.jpg
 author: Thomas Vaeth
 tags: 
   - Dummy Text

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -231,6 +231,10 @@ models:
         label: Date
         description: The publish date of the post.
         required: true
+      - name: description
+        type: string
+        label: Description
+        description: The description used in meta tags.
       - name: image
         type: image
         label: Featured image
@@ -248,6 +252,7 @@ models:
     type: page
     label: Page
     template: page
+    exclude: "_posts/**"
     fields:
       - type: string
         name: title

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,260 @@
+stackbitVersion: "~0.2.0"
+ssgName: jekyll
+buildCommand: "bundle install && bundle exec jekyll build" 
+staticDir: ""
+uploadDir: assets/images
+publishDir: "_site"
+pagesDir: ""
+pageTemplateKey: layout
+models:
+  config:
+    type: config
+    label: Global Site Config
+    fields:
+      - type: string
+        name: email
+        label: Your email address
+      - type: string
+        name: baseurl
+        label: Baseurl
+        description: The subpath of your site, e.g. /blog, for generating urls.
+      - type: string
+        name: permalink
+        label: Permalink
+        description: The permalink pattern.
+      - type: string
+        name: google_analytics
+        label: Google Analytics
+        description: Your Google Analytics identifier. For example, UA-99631805-1.
+      - type: string
+        name: name
+        label: Your name
+        description: Your name used in meta tags.
+      - type: string
+        name: title
+        label: Site Title
+        description: The title displayed in the site header, title tag.
+      - type: string
+        name: description
+        label: Description
+        description: The default description displayed in meta tags.
+      - type: string
+        name: url
+        label: Url
+        description: The base hostname & protocol for your site, e.g. http://example.com
+      - type: string
+        name: twitter_username
+        label: Twitter username
+        description: Twitter username used in meta tags.
+      - type: image
+        name: default_img
+        label: Default image
+        description: Default site image used in meta tags.
+      - type: list
+        name: social
+        label: Social links
+        description: Footer social links.
+        items:
+          type: object
+          labelField: name
+          fields:
+            - type: string
+              name: name
+              label: Title
+              required: true
+            - type: string
+              name: url
+              label: URL
+      - type: image
+        name: contact_img
+        label: Contact form image
+        description: Image for contact form.
+      - type: string
+        name: formcarry
+        label: Formcarry
+        description: Formcarry form URL.
+      - type: string
+        name: disqus
+        label: Disqus username
+        description: The shortname for your Disqus site to enable comments.
+      - type: string
+        name: mailchimp_action
+        label: Mailchimp action
+        description: Mailchimp action URL.
+      - type: string
+        name: mailchimp_input
+        label: Mailchimp input
+        description: Mailchimp hidden input field name value.
+      - type: list
+        name: author
+        label: Author
+        items:
+          type: object
+          labelField: name
+          fields:
+            - type: string
+              name: name
+              label: Name
+              required: true
+            - type: string
+              name: bio
+              label: Bio  
+            - type: string
+              name: url
+              label: URL
+      - type: string
+        name: markdown
+        label: Markdown
+        hidden: true
+      - type: list
+        name: plugins
+        label: Plugins
+        items:
+          type: string
+      - type: object
+        name: compress_html
+        label: Compress HTML
+        hidden: true
+        fields:
+          - type: string
+            name: clippings
+            label: Clippings
+          - type: string
+            name: comments
+            label: Comments
+          - type: list
+            name: startings
+            label: Startings
+            items:
+              type: string
+      - type: object
+        name: pagination
+        label: Pagination setings
+        fields:
+          - type: boolean
+            name: enabled
+            label: Pagination enabled
+            default: true
+          - type: boolean
+            name: debug
+            label: Debug
+            default: false
+          - type: number
+            name: per_page
+            label: Number of posts per page
+          - type: string
+            name: permalink
+            label: Permalink
+            description: The permalink pattern.
+          - type: string
+            name: title
+            label: Title
+          - type: number
+            name: limit
+            label: Limit
+          - type: string
+            name: sort_field
+            label: Sort field
+          - type: boolean
+            name: sort_reverse
+            label: Sort reverse
+            default: true
+      - type: list
+        name: exclude
+        label: Exclude
+        items:
+          type: string
+        hidden: true
+      - type: object
+        name: autopages
+        label: Autopages setings
+        fields:
+          - type: boolean
+            name: enabled
+            label: Autopages enabled
+            default: true
+          - type: object
+            name: categories
+            label: Categories
+            fields:
+              - type: boolean
+                name: enabled
+                label: Categories enabled
+                default: false
+          - type: object
+            name: collections
+            label: Collections
+            fields:
+              - type: boolean
+                name: enabled
+                label: Collections enabled
+                default: false
+          - type: object
+            name: tags
+            label: Tags
+            fields:
+              - type: list
+                name: layouts
+                label: Layouts
+                items:
+                  type: string
+              - type: string
+                name: title
+                label: Title
+              - type: string
+                name: permalink
+                label: Permalink
+              - type: object
+                name: slugify
+                label: Slugify
+                fields:
+                - type: string
+                  name: mode
+                  label: mode
+                - type: boolean
+                  name: cased
+                  label: Cased
+                  default: true
+  post:
+    type: page
+    label: Post
+    template: post
+    folder: _posts
+    fields:
+      - name: title
+        type: string
+        label: Title
+        description: The title of the post.
+        required: true
+      - name: date
+        type: date
+        label: Date
+        description: The publish date of the post.
+        required: true
+      - name: image
+        type: image
+        label: Featured image
+        description: The featured image of the post.
+      - name: author
+        type: string
+        label: Author
+        description: The author of the post.
+      - name: tags
+        type: list
+        label: Tags
+        items:
+          type: string
+  page:
+    type: page
+    label: Page
+    template: page
+    fields:
+      - type: string
+        name: title
+        label: Title
+        description: The title of the page.
+        required: true
+      - type: image
+        name: image
+        label: Featured image
+        description: The featured image of the page.

--- a/style-guide.md
+++ b/style-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Style Guide
-image: /assets/images/placeholder-18.jpg
+image: assets/images/placeholder-18.jpg
 ---
 <p>My name is Thomas Vaeth and this is Barber. 💈 Barber is a minimal blog theme with a masonry grid layout and infinite scroll. <a href="http://samesies.io" target="_blank">Samesies</a> builds themes for Ghost, WordPress, and Jekyll and they are only available through ThemeForest.</p>
 


### PR DESCRIPTION
Hey Thomas,

this pull request adds [Stackbit](https://www.stackbit.com/) support to the Barber Jekyll theme. It adds the "stackbit.yaml" file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS, Sanity & Contentful) and deploys the site to Netlify in one click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/barber-jekyll (note the "Create with Stackbit" button in the readme will import the theme from your repo so until the PR is merged it won't work).

I think this is an awesome feature and a very low impact addition to your existing theme structure, pretty much just the stackbit.yaml file and few adjustments. If you have questions or feedback, I'm happy to discuss.

Best,
Tomas