### PR TITLE
Excluding user-space installed bundle 'vendor' directory.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,3 +83,4 @@ exclude:
   - gulpfile.js
   - package.json
   - README.md
+  - vendor


### PR DESCRIPTION
Bundle recommends installing to "vendor" folder, so if you user-space install it based on the recommendation, the site will not start

```
Your user account isn't allowed to install to the system RubyGems.
  You can cancel this installation and run:

      bundle install --path vendor/bundle

  to install the gems into ./vendor/bundle/, or you can enter your password
  and install the bundled gems to RubyGems using sudo.
```

Results in

```
            Error: could not read file /Users/temp/barber-jekyll/vendor/bundle/ruby/2.6.0/gems/jekyll-3.8.5/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.6.0/gems/jekyll-3.8.5/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.6.0/gems/jekyll-3.8.5/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```