### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ autopages:
       cased: true
 ```
 
-You can change the URL the [contact form](#contact-form) is sent to, add Google Analytics, change the SEO settings, grow your website with additional authors, and much more.
+You can change the URL the [contact form](#contact-form) is sent to, change the SEO settings, grow your website with additional authors, and much more.
 
 ### Create Posts
 All posts go upder the ````_posts```` directory. You can also have a ````_drafts```` directory with posts that will on your development page, but not in production.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Almost everything to personalize your site is in the ````_config.yml````.
 email: okay@samesies.io
 baseurl: ""
 permalink: /:year/:month/:day/:title/
-google_analytics: 
 
 name: Thomas Vaeth
 title: The Barber Theme

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@
 email: okay@samesies.io
 baseurl: ""
 permalink: /:year/:month/:day/:title/
-google_analytics: 
 
 name: Thomas Vaeth
 title: The Barber Theme

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,14 +32,3 @@
 
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.baseurl }}">
 <link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl }}">
-
-{% if site.google_analytics %}
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
-  </script>
-{% endif %}


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/